### PR TITLE
[BUGFIX] shortening details_nr for writelog method

### DIFF
--- a/Classes/Hook/ProcessCmdmapClass.php
+++ b/Classes/Hook/ProcessCmdmapClass.php
@@ -44,7 +44,7 @@ class ProcessCmdmapClass
                 /** @var CacheManager $cacheManager */
                 $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
                 $cacheManager->flushCachesInGroup('pages');
-                $GLOBALS['BE_USER']->writelog(4,0,0,1572862456,'Frontend Cache Clear by deleting Cookie Panel or Group (OM Cookie manager)',[]);
+                $GLOBALS['BE_USER']->writelog(4,0,0,15728,'Frontend Cache Clear by deleting Cookie Panel or Group (OM Cookie manager)',[]);
             }
         }
     }

--- a/Classes/Hook/ProcessDatamapClass.php
+++ b/Classes/Hook/ProcessDatamapClass.php
@@ -46,7 +46,7 @@ class ProcessDatamapClass
             /** @var CacheManager $cacheManager */
             $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
             $cacheManager->flushCachesInGroup('pages');
-            $GLOBALS['BE_USER']->writelog(4,0,0,1572862456,'Frontend Cache Clear by saving Om Cookie Panel or Group(OM Cookie manager)',[]);
+            $GLOBALS['BE_USER']->writelog(4,0,0,15728,'Frontend Cache Clear by saving Om Cookie Panel or Group(OM Cookie manager)',[]);
         }
     }
 }


### PR DESCRIPTION
I get an error while i save, delete or move a group or a panel in TYPO3 backend. This happen because the `details_nr` field in the database table is declared as `smallint (6)` and can't hold 10 digits. Would appreciate it if you can merge and release this fix. 👍 

**Get Error:**
`An exception occurred while executing 'INSERT INTO `sys_log` (`userid`, `type`, `action`, `error`, `details_nr`, `details`, `log_data`, `tablename`, `recuid`, `IP`, `tstamp`, `event_pid`, `NEWid`, `workspace`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params [1, 4, 0, 0, 1572862456, "Frontend Cache Clear by deleting Cookie Panel or Group (OM Cookie manager)", "a:0:{}", "", 0, "172.18.0.5", 1581540773, -1, "", 0]: Out of range value for column 'details_nr' at row 1`

close #4 