### PR TITLE
[TASK] move addStaticFile to TCA/Overrides/sys_template.php, move reg…

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,4 @@
+<?php
+defined('TYPO3_MODE') || die('Access denied.');
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('om_cookie_manager', 'Configuration/TypoScript', 'OM Cookie Manager');

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,8 @@
+<?php
+defined('TYPO3_MODE') || die('Access denied.');
+
+\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
+    'OM.OmCookieManager',
+    'Main',
+    'OM Cookie Manager'
+);

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -5,13 +5,6 @@ call_user_func(
     function()
     {
 
-        \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-            'OM.OmCookieManager',
-            'Main',
-            'OM Cookie Manager'
-        );
-
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('om_cookie_manager', 'Configuration/TypoScript', 'OM Cookie Manager');
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('mod.web_list.hideTables =  tx_omcookiemanager_domain_model_cookie,tx_omcookiemanager_domain_model_cookiehtml' . PHP_EOL . ' mod.web_list.deniedNewTables = tx_omcookiemanager_domain_model_cookie,tx_omcookiemanager_domain_model_cookiehtml');
 
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addLLrefForTCAdescr('tx_omcookiemanager_domain_model_cookie', 'EXT:om_cookie_manager/Resources/Private/Language/locallang_csh_tx_omcookiemanager_domain_model_cookie.xlf');


### PR DESCRIPTION
…isterPlugin to TCA/Overrides/tt_content.php

Fixes an issue during "typo3cms upgrade:prepare" with typo3_console:^7 and TYPO3 ^11.5. typo3_console will try to load the ext_tables.php but this will result in "Warning: Undefined global variable $TCA in [...]/typo3/sysext/core/Classes/Utility/ExtensionManagementUtility.php line 1225". And this results ultimately into a different exception like " The package "X" depends on "Y" which is not present in the system."