### PR TITLE
[TASK] Update TCA and ext_emconf.php with typo3-rector

### DIFF
--- a/Configuration/TCA/tx_omcookiemanager_domain_model_cookie.php
+++ b/Configuration/TCA/tx_omcookiemanager_domain_model_cookie.php
@@ -19,9 +19,6 @@ return [
         'searchFields' => 'name,description,lifetime,provider',
         'iconfile' => 'EXT:om_cookie_manager/Resources/Public/Icons/Extension.svg'
     ],
-    'interface' => [
-        'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, name, description, lifetime, provider, cookie_group, cookie_html',
-    ],
     'types' => [
         '1' => ['showitem' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, name, description, lifetime, provider, cookie_group, cookie_html'],
     ],
@@ -30,22 +27,11 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'special' => 'languages',
-                'items' => [
-                    [
-                        'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
-                        -1,
-                        'flags-multiple'
-                    ]
-                ],
-                'default' => 0,
+                'type' => 'language'
             ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',

--- a/Configuration/TCA/tx_omcookiemanager_domain_model_cookiegroup.php
+++ b/Configuration/TCA/tx_omcookiemanager_domain_model_cookiegroup.php
@@ -19,9 +19,6 @@ return [
         'searchFields' => 'name,description',
         'iconfile' => 'EXT:om_cookie_manager/Resources/Public/Icons/cookie_grp.svg'
     ],
-    'interface' => [
-        'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, name, gtm_event_name, description, essential, cookies',
-    ],
     'types' => [
         '1' => ['showitem' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, name, gtm_event_name, description, essential, cookies'],
     ],
@@ -30,22 +27,11 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'special' => 'languages',
-                'items' => [
-                    [
-                        'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
-                        -1,
-                        'flags-multiple'
-                    ]
-                ],
-                'default' => 0,
+                'type' => 'language'
             ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',
@@ -158,7 +144,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['LLL:EXT:lang/locallang_core.xlf:labels.enabled'],
+                    ['LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.enabled'],
                 ],
                 'default' => 0,
             ]

--- a/Configuration/TCA/tx_omcookiemanager_domain_model_cookiehtml.php
+++ b/Configuration/TCA/tx_omcookiemanager_domain_model_cookiehtml.php
@@ -19,9 +19,6 @@ return [
         'searchFields' => 'html',
         'iconfile' => 'EXT:om_cookie_manager/Resources/Public/Icons/code-signs.svg'
     ],
-    'interface' => [
-        'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, html, insert_place',
-    ],
     'types' => [
         '1' => ['showitem' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, html, insert_place'],
     ],
@@ -30,22 +27,11 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'special' => 'languages',
-                'items' => [
-                    [
-                        'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
-                        -1,
-                        'flags-multiple'
-                    ]
-                ],
-                'default' => 0,
+                'type' => 'language'
             ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',

--- a/Configuration/TCA/tx_omcookiemanager_domain_model_cookiepanel.php
+++ b/Configuration/TCA/tx_omcookiemanager_domain_model_cookiepanel.php
@@ -19,9 +19,6 @@ return [
         'searchFields' => 'name,description,link',
         'iconfile' => 'EXT:om_cookie_manager/Resources/Public/Icons/cookie_panel_icon.svg'
     ],
-    'interface' => [
-        'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, name, description, link, groups',
-    ],
     'types' => [
         '1' => ['showitem' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, name, description, link, groups'],
     ],
@@ -30,22 +27,11 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'special' => 'languages',
-                'items' => [
-                    [
-                        'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
-                        -1,
-                        'flags-multiple'
-                    ]
-                ],
-                'default' => 0,
+                'type' => 'language'
             ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,8 +13,5 @@ $EM_CONF[$_EXTKEY] = [
     'author' => 'Oliver Pfaff',
     'author_email' => 'info@olli-machts.de',
     'state' => 'stable',
-    'uploadfolder' => 0,
-    'createDirs' => '',
-    'clearCacheOnLoad' => 0,
     'version' => '12.0.0',
 ];


### PR DESCRIPTION
- interface/showRecordFieldList removed as it is obsolete
- language field migrated to type "language"
- exclude => true removed from l10n_parent as this is the default for this field
- obsolete config options removed from ext_emconf.php