### PR TITLE
TYPO3 v12 Compatibility Changes

### DIFF
--- a/Configuration/TCA/tx_omcookiemanager_domain_model_cookie.php
+++ b/Configuration/TCA/tx_omcookiemanager_domain_model_cookie.php
@@ -5,7 +5,6 @@ return [
         'label' => 'name',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'versioningWS' => true,
         'languageField' => 'sys_language_uid',
         'transOrigPointerField' => 'l10n_parent',
@@ -37,9 +36,7 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'default' => 0,
-                'items' => [
-                    ['', 0],
-                ],
+                'items' => [],
                 'foreign_table' => 'tx_omcookiemanager_domain_model_cookie',
                 'foreign_table_where' => 'AND {#tx_omcookiemanager_domain_model_cookie}.{#pid}=###CURRENT_PID### AND {#tx_omcookiemanager_domain_model_cookie}.{#sys_language_uid} IN (-1,0)',
             ],
@@ -65,8 +62,7 @@ return [
                 'renderType' => 'checkboxToggle',
                 'items' => [
                     [
-                        0 => '',
-                        1 => '',
+                        'label' => '',
                         'invertStateDisplay' => true
                     ]
                 ],
@@ -77,8 +73,7 @@ return [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.starttime',
             'config' => [
                 'type' => 'input',
-                'renderType' => 'inputDateTime',
-                'eval' => 'datetime,int',
+                'renderType' => 'datetime',
                 'default' => 0,
                 'behaviour' => [
                     'allowLanguageSynchronization' => true
@@ -90,8 +85,7 @@ return [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.endtime',
             'config' => [
                 'type' => 'input',
-                'renderType' => 'inputDateTime',
-                'eval' => 'datetime,int',
+                'renderType' => 'datetime',
                 'default' => 0,
                 'range' => [
                     'upper' => mktime(0, 0, 0, 1, 1, 2038)
@@ -108,7 +102,8 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => 30,
-                'eval' => 'trim,required'
+                'eval' => 'trim',
+                'required' => true
             ],
         ],
         'description' => [

--- a/Configuration/TCA/tx_omcookiemanager_domain_model_cookiegroup.php
+++ b/Configuration/TCA/tx_omcookiemanager_domain_model_cookiegroup.php
@@ -5,7 +5,6 @@ return [
         'label' => 'name',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'versioningWS' => true,
         'languageField' => 'sys_language_uid',
         'transOrigPointerField' => 'l10n_parent',
@@ -38,9 +37,7 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'default' => 0,
-                'items' => [
-                    ['', 0],
-                ],
+                'items' => [],
                 'foreign_table' => 'tx_omcookiemanager_domain_model_cookiegroup',
                 'foreign_table_where' => 'AND {#tx_omcookiemanager_domain_model_cookiegroup}.{#pid}=###CURRENT_PID### AND {#tx_omcookiemanager_domain_model_cookiegroup}.{#sys_language_uid} IN (-1,0)',
             ],
@@ -66,8 +63,7 @@ return [
                 'renderType' => 'checkboxToggle',
                 'items' => [
                     [
-                        0 => '',
-                        1 => '',
+                        'label' => '',
                         'invertStateDisplay' => true
                     ]
                 ],
@@ -145,7 +141,9 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.enabled'],
+                    [
+                        'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.enabled'
+                    ],
                 ],
                 'default' => 0,
             ]

--- a/Configuration/TCA/tx_omcookiemanager_domain_model_cookiehtml.php
+++ b/Configuration/TCA/tx_omcookiemanager_domain_model_cookiehtml.php
@@ -5,7 +5,6 @@ return [
         'label' => 'html',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'versioningWS' => true,
         'languageField' => 'sys_language_uid',
         'transOrigPointerField' => 'l10n_parent',
@@ -37,9 +36,7 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'default' => 0,
-                'items' => [
-                    ['', 0],
-                ],
+                'items' => [],
                 'foreign_table' => 'tx_omcookiemanager_domain_model_cookiehtml',
                 'foreign_table_where' => 'AND {#tx_omcookiemanager_domain_model_cookiehtml}.{#pid}=###CURRENT_PID### AND {#tx_omcookiemanager_domain_model_cookiehtml}.{#sys_language_uid} IN (-1,0)',
             ],
@@ -65,8 +62,7 @@ return [
                 'renderType' => 'checkboxToggle',
                 'items' => [
                     [
-                        0 => '',
-                        1 => '',
+                        'label' => '',
                         'invertStateDisplay' => true
                     ]
                 ],
@@ -119,8 +115,14 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'items' => [
-                    ['Header', 0],
-                    ['Body', 1],
+                    [
+                        'label' => 'Header',
+                        'value' => 0,
+                    ],
+                    [
+                        'label' => 'Body',
+                        'value' => 1,
+                    ],
                 ],
                 'size' => 1,
                 'maxitems' => 1,

--- a/Configuration/TCA/tx_omcookiemanager_domain_model_cookiepanel.php
+++ b/Configuration/TCA/tx_omcookiemanager_domain_model_cookiepanel.php
@@ -5,7 +5,6 @@ return [
         'label' => 'name',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'versioningWS' => true,
         'languageField' => 'sys_language_uid',
         'transOrigPointerField' => 'l10n_parent',
@@ -37,9 +36,7 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'default' => 0,
-                'items' => [
-                    ['', 0],
-                ],
+                'items' => [],
                 'foreign_table' => 'tx_omcookiemanager_domain_model_cookiepanel',
                 'foreign_table_where' => 'AND tx_omcookiemanager_domain_model_cookiepanel.pid=###CURRENT_PID### AND tx_omcookiemanager_domain_model_cookiepanel.sys_language_uid IN (-1,0)',
             ],
@@ -65,8 +62,7 @@ return [
                 'renderType' => 'checkboxToggle',
                 'items' => [
                     [
-                        0 => '',
-                        1 => '',
+                        'label' => '',
                         'invertStateDisplay' => true
                     ]
                 ],
@@ -77,8 +73,7 @@ return [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.starttime',
             'config' => [
                 'type' => 'input',
-                'renderType' => 'inputDateTime',
-                'eval' => 'datetime,int',
+                'renderType' => 'datetime',
                 'default' => 0,
                 'behaviour' => [
                     'allowLanguageSynchronization' => true
@@ -90,8 +85,7 @@ return [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.endtime',
             'config' => [
                 'type' => 'input',
-                'renderType' => 'inputDateTime',
-                'eval' => 'datetime,int',
+                'renderType' => 'datetime',
                 'default' => 0,
                 'range' => [
                     'upper' => mktime(0, 0, 0, 1, 1, 2038)
@@ -134,9 +128,8 @@ return [
             'label' => 'LLL:EXT:om_cookie_manager/Resources/Private/Language/locallang_db.xlf:tx_omcookiemanager_domain_model_cookiepanel.link',
             'config' => [
                 'type' => 'input',
-                'renderType' => 'inputLink',
-                'size' => 30,
-                'eval' => 'trim'
+                'renderType' => 'link',
+                'size' => 30
             ],
         ],
         'groups' => [


### PR DESCRIPTION
- Remove deprecated 'cruser_id' from TCA 
- Switch to new 'items' array format
- Replace 'inputDateTime' fields with new field type 'datetime'
- Replace 'inputLink' fields with new field type 'link'